### PR TITLE
Add simple JSON-RPC layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,25 @@ After building the JAR, you can package it into a Docker image:
 docker build -t ipromt .
 ```
 
-Run the container and interact with it over standard input:
+Run the container and interact with it over standard input. Each line you send must be a JSON-RPC request:
 
 ```
 docker run --rm -i ipromt
 ```
 
-When the server is running, type `list` to display available prompt names or enter a prompt name to get its text. The server reads from standard input until EOF.
+Example request to list available prompts:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"listPrompts"}
+```
+
+Example request to get a specific prompt:
+
+```json
+{"jsonrpc":"2.0","id":2,"method":"getPrompt","params":{"name":"hello"}}
+```
+
+The server will respond with a JSON-RPC response per request.
 
 
 ## GitHub Copilot configuration

--- a/mcp-server/pom.xml
+++ b/mcp-server/pom.xml
@@ -11,6 +11,13 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
     </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>

--- a/mcp-server/src/main/java/org/example/Main.java
+++ b/mcp-server/src/main/java/org/example/Main.java
@@ -2,10 +2,14 @@ package org.example;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class Main {
     public static void main(String[] args) throws Exception {
         PromptService service = new PromptService();
+        ObjectMapper mapper = new ObjectMapper();
         BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
         String line;
         while ((line = reader.readLine()) != null) {
@@ -13,16 +17,55 @@ public class Main {
             if (line.isEmpty()) {
                 continue;
             }
-            if ("list".equalsIgnoreCase(line)) {
-                System.out.println(String.join("\n", service.names()));
-            } else {
-                String result = service.getPrompt(line);
-                if (result != null) {
-                    System.out.println(result);
-                } else {
-                    System.out.println("Prompt not found");
-                }
+            JsonNode req;
+            try {
+                req = mapper.readTree(line);
+            } catch (Exception e) {
+                continue; // ignore malformed input
             }
+            String method = req.path("method").asText();
+            JsonNode params = req.path("params");
+            String id = req.has("id") ? req.get("id").asText() : null;
+
+            Object result = null;
+            boolean error = false;
+            String errorMsg = null;
+
+            if ("listPrompts".equals(method)) {
+                result = service.names();
+            } else if ("getPrompt".equals(method)) {
+                String name = params.path("name").asText(null);
+                if (name == null) {
+                    error = true;
+                    errorMsg = "Missing parameter 'name'";
+                } else {
+                    String prompt = service.getPrompt(name);
+                    if (prompt != null) {
+                        result = prompt;
+                    } else {
+                        error = true;
+                        errorMsg = "Prompt not found";
+                    }
+                }
+            } else {
+                error = true;
+                errorMsg = "Method not found";
+            }
+
+            ObjectNode resp = mapper.createObjectNode();
+            resp.put("jsonrpc", "2.0");
+            if (id != null) {
+                resp.put("id", id);
+            }
+            if (error) {
+                ObjectNode err = mapper.createObjectNode();
+                err.put("code", -32602);
+                err.put("message", errorMsg);
+                resp.set("error", err);
+            } else {
+                resp.set("result", mapper.valueToTree(result));
+            }
+            System.out.println(mapper.writeValueAsString(resp));
         }
     }
 }


### PR DESCRIPTION
## Summary
- add jackson to the Maven dependencies
- update `Main` to read and respond using JSON‑RPC
- document how to send requests via JSON‑RPC

## Testing
- `mvn -f mcp-server/pom.xml -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6870055041608321b28637324dbb1b66