### PR TITLE
Add minimal MCP server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # iPromt - MCP Server Example
 
-This repository contains a minimal command line application that provides access to custom prompts.
-Prompts are loaded from `src/main/resources/prompts.properties` at startup.
+This repository contains a minimal implementation of a Message Channel Protocol (MCP) server that exposes two simple tools backed by a prompt library.
+Prompts are loaded from `mcp-server/src/main/resources/prompts.properties` at startup.
+
+The server understands the standard MCP methods (`initialize`, `getManifest`, `invokeTool`, `getToolMetadata`, `getToolSchema`, and `shutdown`) and communicates via JSON-RPC over standard input and output.
 
 ## Building
 
-```
+```bash
 mvn -f mcp-server/pom.xml package
 ```
 
 ## Running
 
-```
+```bash
 java -jar mcp-server/target/mcp-server.jar
 ```
 
@@ -19,34 +21,33 @@ java -jar mcp-server/target/mcp-server.jar
 
 After building the JAR, you can package it into a Docker image:
 
-```
+```bash
 docker build -t ipromt .
 ```
 
-Run the container and interact with it over standard input. Each line you send must be a JSON-RPC request:
+Run the container and interact with it using MCP JSON-RPC messages:
 
-```
+```bash
 docker run --rm -i ipromt
 ```
 
-Example request to list available prompts:
+Example request to list available prompts using MCP `invokeTool`:
 
 ```json
-{"jsonrpc":"2.0","id":1,"method":"listPrompts"}
+{"jsonrpc":"2.0","id":1,"method":"invokeTool","params":{"name":"listPrompts","input":{}}}
 ```
 
 Example request to get a specific prompt:
 
 ```json
-{"jsonrpc":"2.0","id":2,"method":"getPrompt","params":{"name":"hello"}}
+{"jsonrpc":"2.0","id":2,"method":"invokeTool","params":{"name":"getPrompt","input":{"name":"hello"}}}
 ```
 
-The server will respond with a JSON-RPC response per request.
-
+The server will respond with a JSON-RPC response for each request.
 
 ## GitHub Copilot configuration
 
-To use this MCP server with GitHub Copilot, add an entry to your `mcp.json` file. The `command` array should launch the server and Copilot will communicate with it over standard input. When running the JAR directly it looks like this:
+To use this MCP server with GitHub Copilot, add an entry to your `mcp.json` file. The `command` array should launch the server and Copilot will communicate with it over standard input:
 
 ```json
 {
@@ -60,7 +61,7 @@ To use this MCP server with GitHub Copilot, add an entry to your `mcp.json` file
 }
 ```
 
-Place the JAR built from this repository in the location referenced by `command`. Copilot will start the process and send prompt requests via stdin.
+Place the JAR built from this repository in the location referenced by `command`. Copilot will start the process and send MCP requests via stdin.
 
 If you package the server into Docker instead, your `command` array should start the container:
 
@@ -75,5 +76,3 @@ If you package the server into Docker instead, your `command` array should start
   ]
 }
 ```
-
-

--- a/mcp-server/src/main/java/org/example/Main.java
+++ b/mcp-server/src/main/java/org/example/Main.java
@@ -1,71 +1,129 @@
 package org.example;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.example.mcp.GetPromptTool;
+import org.example.mcp.ListPromptsTool;
+import org.example.mcp.Tool;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class Main {
-    public static void main(String[] args) throws Exception {
+    private final Map<String, Tool> tools = new LinkedHashMap<>();
+    private final ObjectMapper mapper = new ObjectMapper();
+    private boolean running = true;
+
+    public Main() {
         PromptService service = new PromptService();
-        ObjectMapper mapper = new ObjectMapper();
+        register(new ListPromptsTool(service));
+        register(new GetPromptTool(service));
+    }
+
+    private void register(Tool tool) {
+        tools.put(tool.getName(), tool);
+    }
+
+    private JsonNode manifest() {
+        ObjectNode m = mapper.createObjectNode();
+        m.put("name", "ipromt");
+        m.put("description", "Example MCP server for prompts");
+        m.put("version", "1.0");
+        m.put("schemaVersion", "v1");
+        var arr = m.putArray("tools");
+        for (Tool t : tools.values()) {
+            ObjectNode tool = arr.addObject();
+            tool.put("name", t.getName());
+            tool.put("description", t.getDescription());
+        }
+        return m;
+    }
+
+    private JsonNode toolMetadata(String name) {
+        Tool t = tools.get(name);
+        if (t == null) return null;
+        ObjectNode meta = mapper.createObjectNode();
+        meta.put("name", t.getName());
+        meta.put("description", t.getDescription());
+        return meta;
+    }
+
+    private JsonNode toolSchema(String name) {
+        Tool t = tools.get(name);
+        if (t == null) return null;
+        ObjectNode schema = mapper.createObjectNode();
+        schema.set("input", t.getInputSchema());
+        schema.set("output", t.getOutputSchema());
+        return schema;
+    }
+
+    private JsonNode invoke(String name, JsonNode input) throws Exception {
+        Tool t = tools.get(name);
+        if (t == null) return null;
+        return t.invoke(input);
+    }
+
+    private void run() throws Exception {
         BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
         String line;
-        while ((line = reader.readLine()) != null) {
+        while (running && (line = reader.readLine()) != null) {
             line = line.trim();
-            if (line.isEmpty()) {
-                continue;
-            }
+            if (line.isEmpty()) continue;
             JsonNode req;
             try {
                 req = mapper.readTree(line);
             } catch (Exception e) {
-                continue; // ignore malformed input
+                continue; // ignore malformed
             }
             String method = req.path("method").asText();
             JsonNode params = req.path("params");
-            String id = req.has("id") ? req.get("id").asText() : null;
-
-            Object result = null;
-            boolean error = false;
-            String errorMsg = null;
-
-            if ("listPrompts".equals(method)) {
-                result = service.names();
-            } else if ("getPrompt".equals(method)) {
-                String name = params.path("name").asText(null);
-                if (name == null) {
-                    error = true;
-                    errorMsg = "Missing parameter 'name'";
-                } else {
-                    String prompt = service.getPrompt(name);
-                    if (prompt != null) {
-                        result = prompt;
-                    } else {
-                        error = true;
-                        errorMsg = "Prompt not found";
-                    }
-                }
-            } else {
-                error = true;
-                errorMsg = "Method not found";
-            }
-
+            JsonNode idNode = req.get("id");
             ObjectNode resp = mapper.createObjectNode();
             resp.put("jsonrpc", "2.0");
-            if (id != null) {
-                resp.put("id", id);
-            }
-            if (error) {
+            if (idNode != null) resp.set("id", idNode);
+            try {
+                switch (method) {
+                    case "initialize" -> resp.set("result", mapper.createObjectNode().put("ready", true));
+                    case "getManifest" -> resp.set("result", manifest());
+                    case "getToolMetadata" -> {
+                        String name = params.path("name").asText(null);
+                        JsonNode meta = toolMetadata(name);
+                        if (meta == null) throw new IllegalArgumentException("Unknown tool");
+                        resp.set("result", meta);
+                    }
+                    case "getToolSchema" -> {
+                        String name = params.path("name").asText(null);
+                        JsonNode schema = toolSchema(name);
+                        if (schema == null) throw new IllegalArgumentException("Unknown tool");
+                        resp.set("result", schema);
+                    }
+                    case "invokeTool" -> {
+                        String name = params.path("name").asText(null);
+                        JsonNode input = params.path("input");
+                        JsonNode out = invoke(name, input);
+                        if (out == null) throw new IllegalArgumentException("Unknown tool");
+                        resp.set("result", out);
+                    }
+                    case "shutdown" -> {
+                        resp.set("result", mapper.createObjectNode());
+                        running = false;
+                    }
+                    default -> throw new IllegalArgumentException("Method not found");
+                }
+            } catch (Exception e) {
                 ObjectNode err = mapper.createObjectNode();
                 err.put("code", -32602);
-                err.put("message", errorMsg);
+                err.put("message", e.getMessage());
                 resp.set("error", err);
-            } else {
-                resp.set("result", mapper.valueToTree(result));
             }
             System.out.println(mapper.writeValueAsString(resp));
         }
+    }
+
+    public static void main(String[] args) throws Exception {
+        new Main().run();
     }
 }

--- a/mcp-server/src/main/java/org/example/mcp/GetPromptTool.java
+++ b/mcp-server/src/main/java/org/example/mcp/GetPromptTool.java
@@ -1,0 +1,58 @@
+package org.example.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.example.PromptService;
+
+public class GetPromptTool implements Tool {
+    private final PromptService service;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public GetPromptTool(PromptService service) {
+        this.service = service;
+    }
+
+    @Override
+    public String getName() {
+        return "getPrompt";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Retrieve a prompt by name";
+    }
+
+    @Override
+    public JsonNode getInputSchema() {
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", "object");
+        ObjectNode props = schema.putObject("properties");
+        props.putObject("name").put("type", "string");
+        schema.putArray("required").add("name");
+        return schema;
+    }
+
+    @Override
+    public JsonNode getOutputSchema() {
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", "object");
+        ObjectNode props = schema.putObject("properties");
+        props.putObject("prompt").put("type", "string");
+        schema.putArray("required").add("prompt");
+        return schema;
+    }
+
+    @Override
+    public JsonNode invoke(JsonNode input) {
+        String name = input.path("name").asText(null);
+        ObjectNode result = mapper.createObjectNode();
+        String prompt = service.getPrompt(name);
+        if (prompt != null) {
+            result.put("prompt", prompt);
+        } else {
+            result.putNull("prompt");
+        }
+        return result;
+    }
+}

--- a/mcp-server/src/main/java/org/example/mcp/ListPromptsTool.java
+++ b/mcp-server/src/main/java/org/example/mcp/ListPromptsTool.java
@@ -1,0 +1,58 @@
+package org.example.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.example.PromptService;
+
+public class ListPromptsTool implements Tool {
+    private final PromptService service;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public ListPromptsTool(PromptService service) {
+        this.service = service;
+    }
+
+    @Override
+    public String getName() {
+        return "listPrompts";
+    }
+
+    @Override
+    public String getDescription() {
+        return "List available prompt names";
+    }
+
+    @Override
+    public JsonNode getInputSchema() {
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", "object");
+        schema.putObject("properties");
+        schema.putArray("required");
+        return schema;
+    }
+
+    @Override
+    public JsonNode getOutputSchema() {
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", "object");
+        ObjectNode props = schema.putObject("properties");
+        ObjectNode names = props.putObject("names");
+        names.put("type", "array");
+        names.putObject("items").put("type", "string");
+        schema.putArray("required").add("names");
+        return schema;
+    }
+
+    @Override
+    public JsonNode invoke(JsonNode input) {
+        ArrayNode arr = mapper.createArrayNode();
+        for (String name : service.names()) {
+            arr.add(name);
+        }
+        ObjectNode result = mapper.createObjectNode();
+        result.set("names", arr);
+        return result;
+    }
+}

--- a/mcp-server/src/main/java/org/example/mcp/Tool.java
+++ b/mcp-server/src/main/java/org/example/mcp/Tool.java
@@ -1,0 +1,11 @@
+package org.example.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface Tool {
+    String getName();
+    String getDescription();
+    JsonNode getInputSchema();
+    JsonNode getOutputSchema();
+    JsonNode invoke(JsonNode input) throws Exception;
+}

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": [
+    {
+      "id": "ipromt",
+      "command": ["java", "-jar", "mcp-server/target/mcp-server.jar"],
+      "stdin": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- implement MCP server with `initialize`, `getManifest`, `invokeTool`, `getToolMetadata`, `getToolSchema` and `shutdown`
- add simple `listPrompts` and `getPrompt` tools
- document how to run the MCP server and interact with it
- provide an example `mcp.json` configuration

## Testing
- `mvn -f mcp-server/pom.xml -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6870130416488321af7b17b18c3055fb