### PR TITLE
Serve single prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # iPromt - MCP Server Example
 
-This repository contains a minimal implementation of a Message Channel Protocol (MCP) server that exposes two simple tools backed by a prompt library.
-Prompts are loaded from `mcp-server/src/main/resources/prompts.properties` at startup.
+This repository contains a minimal implementation of a Message Channel Protocol (MCP) server built with [Quarkus](https://quarkus.io/) using the [Quarkiverse MCP Server](https://github.com/quarkiverse/quarkus-mcp-server) extension.
+Only a single prompt is served and the text is loaded from `mcp-server/src/main/resources/prompts.properties` at startup.
 
 The server understands the standard MCP methods (`initialize`, `getManifest`, `invokeTool`, `getToolMetadata`, `getToolSchema`, and `shutdown`) and communicates via JSON-RPC over standard input and output.
 

--- a/mcp-server/src/main/java/org/example/Main.java
+++ b/mcp-server/src/main/java/org/example/Main.java
@@ -1,0 +1,14 @@
+package org.example;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+/**
+ * Entry point for the MCP server running on stdio.
+ */
+@QuarkusMain
+public class Main {
+    public static void main(String[] args) {
+        Quarkus.run(args);
+    }
+}

--- a/mcp-server/src/main/java/org/example/PromptLoader.java
+++ b/mcp-server/src/main/java/org/example/PromptLoader.java
@@ -1,0 +1,39 @@
+package org.example;
+
+import io.quarkiverse.mcp.server.PromptManager;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.PromptResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import io.quarkus.runtime.StartupEvent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Loads prompts from the prompts.properties file and registers them with the MCP server.
+ */
+@ApplicationScoped
+public class PromptLoader {
+
+    @Inject
+    PromptManager promptManager;
+
+    void onStart(@Observes StartupEvent event) throws IOException {
+        Properties props = new Properties();
+        try (InputStream in = PromptLoader.class.getResourceAsStream("/prompts.properties")) {
+            if (in != null) {
+                props.load(in);
+            }
+        }
+        for (String name : props.stringPropertyNames()) {
+            String text = props.getProperty(name);
+            promptManager.newPrompt(name)
+                    .setHandler(args -> PromptResponse.withMessages(
+                            PromptMessage.withAssistantRole(text)))
+                    .register();
+        }
+    }
+}

--- a/mcp-server/src/main/resources/prompts.properties
+++ b/mcp-server/src/main/resources/prompts.properties
@@ -1,2 +1,1 @@
 hello=Hello from custom prompt library.
-bye=Goodbye from custom prompt library.


### PR DESCRIPTION
## Summary
- make README mention Quarkiverse server and Quarkus
- implement PromptLoader to load prompts via `PromptManager`
- add Quarkus `Main` entry point

## Testing
- `git fetch --all`
- `mvn -f mcp-server/pom.xml package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6873a12d8e188321a73ce18df6b2d755